### PR TITLE
Restricts direct file access from requests made in the address bar

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,6 +3,12 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME}\.php -f
 RewriteRule ^(.*)$ $1.php
 
+
+## DISABLES DIRECT FILE REQUESTS ##
+RewriteCond %{HTTP_HOST}@@%{HTTP_REFERER} !^([^@]*)@@https?://\1/.*$ [NC]
+RewriteRule \.(js|scss|sass|css)$ - [F]
+
+
 ## EXPIRES CACHING ##
 <IfModule mod_expires.c>
 ExpiresActive On


### PR DESCRIPTION
Using RewriteRule, these two lines of code in the .htaccess file will redirect a client to a 403 error should they attempt to access any file extensions that end with js, scss, sass, or css.  What's cool about the first line is it will work on any website, regardless of what the website name is meaning this trick can work on any root with .htaccess enabled.   

Because it uses a RewriteRule based on a comparison made by RewriteCond, your php will still be able to access these files when generating the content with include(); on the servers end and html can still call JS and CSS files.  The only thing that this does is checks to see if the request being made ends with a .(js,scss,sass, or css) extension and [F] will return 403. 
